### PR TITLE
README.md fix for installing cookiecutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then fill in all the information asked.
 
 If you don't have cookie cutter, install it using:
 ```bash
-npm install cookiecutter -g
+pip install cookiecutter
 ```
 
 Frontend


### PR DESCRIPTION
I also removed reference to npm-cookiecutter as it doesn't seem to work out of the box with the latest nodejs stable or dev branches (6.9.x and 7.x.x)